### PR TITLE
Correctly handle 'transfer-encoding: chunked'

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -148,26 +148,31 @@ Mailjet.prototype.sendRequest = function () {
   
   // Make request
   var req = http.request(options, function (res) {
+    var data = '';
     res.setEncoding('utf8');
     res.on('data', function (chunk) {
-      var data = chunk;
+      data += chunk;
+    });
+
+    res.on('end', function(e) {
       try { data = JSON.parse(data); } catch (e) {}
-      if (cb) {
+      if(cb) {
         cb(null, res.statusCode, data, res.headers);
       } else Promise.emit('complete', {
-        status  : res.statusCode,
-        data    : data,
-        headers : res.headers
+          status  : res.statusCode,
+          data    : data,
+          headers : res.headers
       });
     });
   });
+
 
   req.on('error', function(e) {
     if (cb) {
       cb(e);
     } else Promise.emit('complete', e);
   });
-  
+
   // write data to request body
   req.write(query_string);
   req.end();


### PR DESCRIPTION
The 'data' event should only be used to consume the incoming chunks.
The 'end' event is designed to handle the request end.
